### PR TITLE
Build shared lib; compile with -Wall -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,25 @@
 project(Ice9API)
 cmake_minimum_required(VERSION 3.0)
+
 find_path(LIBUSB_INCLUDE_DIR libusb.h PATH_SUFFIXES "include" "libusb" "libusb-1.0")
 find_library(LIBUSB_LIBRARY usb NAMES usb usb-1.0)
 find_path(FTDI_INCLUDE_DIR ftdi.h PATH_SUFFIXES "libftdi1")
 find_library(FTDI_LIBRARY ftdi NAMES ftdi ftdi1)
-include_directories(BEFORE SYSTEM ${FTDI_INCLUDE_DIR} ${LIBUSB_INCLUDE_DIR})
-add_library(ice9 SHARED sram_flash.c mpsse.c ice9.c ftdi_stream_ice9.c)
+
+set(LIB_SOURCES sram_flash.c mpsse.c ice9.c ftdi_stream_ice9.c)
+add_library(LIB_OBJECTS OBJECT ${LIB_SOURCES})
+set_target_properties(LIB_OBJECTS PROPERTIES POSITION_INDEPENDENT_CODE 1)
+target_compile_options(LIB_OBJECTS PRIVATE -Wall -Werror -Wno-deprecated-declarations)
+target_include_directories(LIB_OBJECTS SYSTEM BEFORE PRIVATE ${FTDI_INCLUDE_DIR} ${LIBUSB_INCLUDE_DIR})
+
+add_library(ice9 SHARED $<TARGET_OBJECTS:LIB_OBJECTS>)
 set_target_properties(ice9 PROPERTIES PUBLIC_HEADER ice9.h)
 target_link_libraries(ice9 ${FTDI_LIBRARY} ${LIBUSB_LIBRARY})
+
+add_library(ice9_static STATIC  $<TARGET_OBJECTS:LIB_OBJECTS>)
+set_target_properties(ice9_static PROPERTIES PUBLIC_HEADER ice9.h)
+target_link_libraries(ice9_static ${FTDI_LIBRARY} ${LIBUSB_LIBRARY})
+
 install(TARGETS ice9 DESTINATION lib)
+install(TARGETS ice9_static DESTINATION lib)
 install(FILES ice9.h DESTINATION include)

--- a/sram_flash.c
+++ b/sram_flash.c
@@ -253,7 +253,6 @@ enum Ice9Error ice9_flash_fpga(const char *filename) {
     const char *devstr = "i:0x3524:0x0001";
     bool slow_clock = false;
     FILE *f = NULL;
-    long file_size = -1;
 
 
     f = fopen(filename, "rb");
@@ -283,8 +282,7 @@ enum Ice9Error ice9_flash_fpga(const char *filename) {
     sram_prepare();
     sram_read_status();
     fprintf(stderr, "Bye.\n");
-    sram_chip_select();
-    send_byte_command(LSC_BITSTREAM_BURST);
+    sram_bitstream_burst();
     while (1) {
         const uint32_t len = 16*1024;
         static unsigned char buffer[16*1024];
@@ -328,8 +326,7 @@ enum Ice9Error ice9_flash_fpga_mem(void *buf, int bufsize) {
     sram_prepare();
     sram_read_status();
     fprintf(stderr, "Bye.\n");
-    sram_chip_select();
-    send_byte_command(LSC_BITSTREAM_BURST);
+    sram_bitstream_burst();
     while (bufsize) {
         const int len = (bufsize < 16*1024) ? bufsize : 16*1024;
         if (verbose)


### PR DESCRIPTION
Updates the build to generate both shared and static libraries. Also builds with `-Wall -Werror` and fixes a few resulting minor compiler errors.