### PR TITLE
Add log macros and logger setter functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_library(LIBUSB_LIBRARY usb NAMES usb usb-1.0)
 find_path(FTDI_INCLUDE_DIR ftdi.h PATH_SUFFIXES "libftdi1")
 find_library(FTDI_LIBRARY ftdi NAMES ftdi ftdi1)
 
-set(LIB_SOURCES sram_flash.c mpsse.c ice9.c ftdi_stream_ice9.c)
+set(LIB_SOURCES sram_flash.c mpsse.c ice9.c ftdi_stream_ice9.c logger.c)
 add_library(LIB_OBJECTS OBJECT ${LIB_SOURCES})
 set_target_properties(LIB_OBJECTS PROPERTIES POSITION_INDEPENDENT_CODE 1)
 target_compile_options(LIB_OBJECTS PRIVATE -Wall -Werror -Wno-deprecated-declarations)

--- a/ftdi_stream_ice9.c
+++ b/ftdi_stream_ice9.c
@@ -48,6 +48,7 @@
 #include <libusb.h>
 
 #include "ftdi.h"
+#include "logger.h"
 
 typedef struct
 {
@@ -110,7 +111,7 @@ ftdi_readstream_cb(struct libusb_transfer *transfer)
     }
     else
     {
-        fprintf(stderr, "unknown status %d\n",transfer->status);
+        LOG_ERROR("ftdi unknown status %d\n",transfer->status);
         state->result = LIBUSB_ERROR_IO;
     }
 }
@@ -259,7 +260,6 @@ ftdi_readstream_ice9(struct ftdi_context *ftdi,
      */
 
     cleanup:
-    fprintf(stderr, "cleanup\n");
     if (transfers)
         free(transfers);
     if (err)

--- a/ice9.c
+++ b/ice9.c
@@ -1,4 +1,5 @@
 #include "ice9.h"
+#include "logger.h"
 #include <time.h>
 #include <libftdi1/ftdi.h>
 #include <stdio.h>
@@ -120,7 +121,7 @@ const char* ice9_error_string(enum Ice9Error code) {
         case NoDataAvailable: return "No Data available for read";
         case PingMismatch: return "Ping mismatch";
         default:
-            printf("Error code %d", code);
+            LOG_INFO("unknown ice9 error code %d\n");
             return "Unknown";
     }
 }
@@ -335,7 +336,7 @@ enum Ice9Error ice9_ping_bridge(struct ice9_handle *hnd, uint8_t pingid) {
     lib_try(ice9_read_words(hnd, &pingret, 1));
     pingret = pingret & 0xFF;
     if (pingret != pingid) {
-        printf("Ping mismatch - sent %x, recv %x\n", pingid, pingret);
+        LOG_INFO("ice9 ping mismatch - sent %x, recv %x\n", pingid, pingret);
         return PingMismatch;
     }
     return OK;

--- a/ice9.h
+++ b/ice9.h
@@ -63,6 +63,10 @@ EXTERN_C struct ice9_handle * ice9_new();
 
 EXTERN_C void ice9_free(struct ice9_handle *hnd);
 
+EXTERN_C void ice9_set_info_logger(void (*log_info)(const char *format, ...));
+
+EXTERN_C void ice9_set_error_logger(void (*log_error)(const char *file, int line, const char *format, ...));
+
 EXTERN_C enum Ice9Error ice9_open(struct ice9_handle *hnd);
 
 EXTERN_C enum Ice9Error ice9_usb_reset(struct ice9_handle *hnd);

--- a/logger.c
+++ b/logger.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <pthread.h>
+
+#include "logger.h"
+
+static pthread_mutex_t s_log_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static void ice9_log_info(const char *format, ...) {
+    char buf[256];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buf, sizeof(buf), format, args);
+    va_end(args);
+    buf[sizeof(buf)-1] = '\0';
+
+    pthread_mutex_lock(&s_log_lock);
+    printf("%s", buf);
+    pthread_mutex_unlock(&s_log_lock);
+}
+
+static void ice9_log_error(const char *file, int line, const char *format, ...) {
+    char buf[256];
+    const int nwritten = snprintf(buf, sizeof(buf), "%s:%d ", file, line);
+    if (nwritten < sizeof(buf)-1) {
+        va_list args;
+        va_start(args, format);
+        vfprintf(stderr, format, args);
+        vsnprintf(buf, sizeof(buf)-nwritten, format, args);
+        va_end(args);
+    }
+    buf[sizeof(buf)-1] = '\0';
+
+    pthread_mutex_lock(&s_log_lock);
+    fprintf(stderr, "%s", buf);
+    pthread_mutex_unlock(&s_log_lock);
+}
+
+void (*ice9_info_logger)(const char *format, ...) = ice9_log_info;
+void (*ice9_error_logger)(const char *file, int line, const char *format, ...) = ice9_log_error;
+
+void ice9_set_info_logger(void (*log_info)(const char *format, ...)) {
+    pthread_mutex_lock(&s_log_lock);
+    ice9_info_logger = log_info;
+    pthread_mutex_unlock(&s_log_lock);
+}
+
+void ice9_set_error_logger(void (*log_error)(const char *file, int line, const char *format, ...)) {
+    pthread_mutex_lock(&s_log_lock);
+    ice9_error_logger = log_error;
+    pthread_mutex_unlock(&s_log_lock);
+}

--- a/logger.h
+++ b/logger.h
@@ -1,0 +1,25 @@
+#ifndef _ICE9_LOGGER_H_
+#define _ICE9_LOGGER_H_
+
+#ifdef __cplusplus
+#define EXTERN_C extern "C"
+#else  // ! __cplusplus
+#define EXTERN_C
+#endif  // __cplusplus
+
+#include <unistd.h>
+
+extern void (*ice9_info_logger)(const char *format, ...);
+extern void (*ice9_error_logger)(const char *file, int line, const char *format, ...);
+
+#define LOG_INFO(fmt, ...)                                        \
+    do {                                                          \
+        ice9_info_logger(fmt, ##__VA_ARGS__); \
+    } while (0);
+
+#define LOG_ERROR(fmt, ...)                                        \
+    do {                                                           \
+        ice9_error_logger(__FILE__, __LINE__, fmt, ##__VA_ARGS__); \
+    } while (0);
+
+#endif  // _ICE9_LOGGER_H_

--- a/sram_flash.c
+++ b/sram_flash.c
@@ -36,6 +36,7 @@
 #include <sys/stat.h>
 
 #include "lattice_cmds.h"
+#include "logger.h"
 #include "mpsse.h"
 #include "ice9.h"
 
@@ -117,7 +118,7 @@ static void print_idcode(uint32_t idcode){
             {
                 connected_device.name = ecp_devices[i].device_name;
                 connected_device.type = TYPE_ECP5;
-                printf("IDCODE: 0x%08x (%s)\n", idcode ,ecp_devices[i].device_name);
+                LOG_INFO("FPGA IDCODE: 0x%08x (%s)\n", idcode ,ecp_devices[i].device_name);
                 return;
             }
     }
@@ -128,54 +129,54 @@ static void print_idcode(uint32_t idcode){
             {
                 connected_device.name = nx_devices[i].device_name;
                 connected_device.type = TYPE_NX;
-                printf("IDCODE: 0x%08x (%s)\n", idcode ,nx_devices[i].device_name);
+                LOG_INFO("FPGA IDCODE: 0x%08x (%s)\n", idcode ,nx_devices[i].device_name);
                 return;
             }
     }
-    printf("IDCODE: 0x%08x does not match :(\n", idcode);
+    LOG_INFO("FPGA IDCODE: 0x%08x does not match :(\n", idcode);
     exit(1);
 }
 
 void print_ecp5_status_register(uint32_t status){	
-	printf("ECP5 Status Register: 0x%08x\n", status);
+	LOG_INFO("ECP5 Status Register: 0x%08x\n", status);
 
 	if(verbose){
-		printf("  Transparent Mode:   %s\n",  status & (1 << 0)  ? "Yes" : "No" );
-		printf("  Config Target:      %s\n",  status & (7 << 1)  ? "eFuse" : "SRAM" );
-		printf("  JTAG Active:        %s\n",  status & (1 << 4)  ? "Yes" : "No" );
-		printf("  PWD Protection:     %s\n",  status & (1 << 5)  ? "Yes" : "No" );
-		printf("  Decrypt Enable:     %s\n",  status & (1 << 7)  ? "Yes" : "No" );
-		printf("  DONE:               %s\n",  status & (1 << 8)  ? "Yes" : "No" );
-		printf("  ISC Enable:         %s\n",  status & (1 << 9)  ? "Yes" : "No" );
-		printf("  Write Enable:       %s\n",  status & (1 << 10) ? "Writable" : "Not Writable");
-		printf("  Read Enable:        %s\n",  status & (1 << 11) ? "Readable" : "Not Readable");
-		printf("  Busy Flag:          %s\n",  status & (1 << 12) ? "Yes" : "No" );
-		printf("  Fail Flag:          %s\n",  status & (1 << 13) ? "Yes" : "No" );
-		printf("  Feature OTP:        %s\n",  status & (1 << 14) ? "Yes" : "No" );
-		printf("  Decrypt Only:       %s\n",  status & (1 << 15) ? "Yes" : "No" );
-		printf("  PWD Enable:         %s\n",  status & (1 << 16) ? "Yes" : "No" );
-		printf("  Encrypt Preamble:   %s\n",  status & (1 << 20) ? "Yes" : "No" );
-		printf("  Std Preamble:       %s\n",  status & (1 << 21) ? "Yes" : "No" );
-		printf("  SPIm Fail 1:        %s\n",  status & (1 << 22) ? "Yes" : "No" );
+		LOG_INFO("  Transparent Mode:   %s\n",  status & (1 << 0)  ? "Yes" : "No" );
+		LOG_INFO("  Config Target:      %s\n",  status & (7 << 1)  ? "eFuse" : "SRAM" );
+		LOG_INFO("  JTAG Active:        %s\n",  status & (1 << 4)  ? "Yes" : "No" );
+		LOG_INFO("  PWD Protection:     %s\n",  status & (1 << 5)  ? "Yes" : "No" );
+		LOG_INFO("  Decrypt Enable:     %s\n",  status & (1 << 7)  ? "Yes" : "No" );
+		LOG_INFO("  DONE:               %s\n",  status & (1 << 8)  ? "Yes" : "No" );
+		LOG_INFO("  ISC Enable:         %s\n",  status & (1 << 9)  ? "Yes" : "No" );
+		LOG_INFO("  Write Enable:       %s\n",  status & (1 << 10) ? "Writable" : "Not Writable");
+		LOG_INFO("  Read Enable:        %s\n",  status & (1 << 11) ? "Readable" : "Not Readable");
+		LOG_INFO("  Busy Flag:          %s\n",  status & (1 << 12) ? "Yes" : "No" );
+		LOG_INFO("  Fail Flag:          %s\n",  status & (1 << 13) ? "Yes" : "No" );
+		LOG_INFO("  Feature OTP:        %s\n",  status & (1 << 14) ? "Yes" : "No" );
+		LOG_INFO("  Decrypt Only:       %s\n",  status & (1 << 15) ? "Yes" : "No" );
+		LOG_INFO("  PWD Enable:         %s\n",  status & (1 << 16) ? "Yes" : "No" );
+		LOG_INFO("  Encrypt Preamble:   %s\n",  status & (1 << 20) ? "Yes" : "No" );
+		LOG_INFO("  Std Preamble:       %s\n",  status & (1 << 21) ? "Yes" : "No" );
+		LOG_INFO("  SPIm Fail 1:        %s\n",  status & (1 << 22) ? "Yes" : "No" );
 		
 		uint8_t bse_error = (status & (7 << 23)) >> 23;
 		switch (bse_error){
-			case 0b000: printf("  BSE Error Code:     No Error (0b000)\n"); break;
-			case 0b001: printf("  BSE Error Code:     ID Error (0b001)\n"); break;
-			case 0b010: printf("  BSE Error Code:     CMD Error - illegal command (0b010)\n"); break;
-			case 0b011: printf("  BSE Error Code:     CRC Error (0b011)\n"); break;
-			case 0b100: printf("  BSE Error Code:     PRMB Error - preamble error (0b100)\n"); break;
-			case 0b101: printf("  BSE Error Code:     ABRT Error - configuration aborted by the user (0b101)\n"); break;
-			case 0b110: printf("  BSE Error Code:     OVFL Error - data overflow error (0b110)\n"); break;
-			case 0b111: printf("  BSE Error Code:     SDM Error - bitstream pass the size of SRAM array (0b111)\n"); break;
+			case 0b000: LOG_INFO("  BSE Error Code:     No Error (0b000)\n"); break;
+			case 0b001: LOG_INFO("  BSE Error Code:     ID Error (0b001)\n"); break;
+			case 0b010: LOG_INFO("  BSE Error Code:     CMD Error - illegal command (0b010)\n"); break;
+			case 0b011: LOG_INFO("  BSE Error Code:     CRC Error (0b011)\n"); break;
+			case 0b100: LOG_INFO("  BSE Error Code:     PRMB Error - preamble error (0b100)\n"); break;
+			case 0b101: LOG_INFO("  BSE Error Code:     ABRT Error - configuration aborted by the user (0b101)\n"); break;
+			case 0b110: LOG_INFO("  BSE Error Code:     OVFL Error - data overflow error (0b110)\n"); break;
+			case 0b111: LOG_INFO("  BSE Error Code:     SDM Error - bitstream pass the size of SRAM array (0b111)\n"); break;
 		}
 
-		printf("  Execution Error:    %s\n",  status & (1 << 26) ? "Yes" : "No" );
-		printf("  ID Error:           %s\n",  status & (1 << 27) ? "Yes" : "No" );
-		printf("  Invalid Command:    %s\n",  status & (1 << 28) ? "Yes" : "No" );
-		printf("  SED Error:          %s\n",  status & (1 << 29) ? "Yes" : "No" );
-		printf("  Bypass Mode:        %s\n",  status & (1 << 30) ? "Yes" : "No" );
-		printf("  Flow Through Mode:  %s\n",  status & (1 << 31) ? "Yes" : "No" );
+		LOG_INFO("  Execution Error:    %s\n",  status & (1 << 26) ? "Yes" : "No" );
+		LOG_INFO("  ID Error:           %s\n",  status & (1 << 27) ? "Yes" : "No" );
+		LOG_INFO("  Invalid Command:    %s\n",  status & (1 << 28) ? "Yes" : "No" );
+		LOG_INFO("  SED Error:          %s\n",  status & (1 << 29) ? "Yes" : "No" );
+		LOG_INFO("  Bypass Mode:        %s\n",  status & (1 << 30) ? "Yes" : "No" );
+		LOG_INFO("  Flow Through Mode:  %s\n",  status & (1 << 31) ? "Yes" : "No" );
 	}
 }
 
@@ -265,23 +266,22 @@ enum Ice9Error ice9_flash_fpga(const char *filename) {
     // Reset
     // ---------------------------------------------------------
 
-    fprintf(stderr, "init...\n");
+    LOG_INFO("ice9 init...\n");
     
     mpsse_init(ifnum, devstr, slow_clock);
     
-    fprintf(stderr, "reset..\n");
+    LOG_INFO("ice9 reset..\n");
     
     sram_reset();
     usleep(100);
         
-    fprintf(stderr, "cdone: %s\n", get_cdone() ? "high" : "low");
+    LOG_INFO("ice9 cdone: %s\n", get_cdone() ? "high" : "low");
 
     sram_refresh_fpga();
     sram_read_id();
     sram_read_status(); 
     sram_prepare();
     sram_read_status();
-    fprintf(stderr, "Bye.\n");
     sram_bitstream_burst();
     while (1) {
         const uint32_t len = 16*1024;
@@ -289,7 +289,7 @@ enum Ice9Error ice9_flash_fpga(const char *filename) {
         int rc = fread(buffer, 1, len, f);
         if (rc <= 0) break;
         if (verbose)
-            fprintf(stderr, "sending %d bytes.\n", rc);
+            LOG_INFO("ice9 sending %d bytes.\n", rc);
         mpsse_send_spi(buffer, rc);
     }
     sram_chip_deselect();
@@ -309,28 +309,27 @@ enum Ice9Error ice9_flash_fpga_mem(void *buf, int bufsize) {
     // Reset
     // ---------------------------------------------------------
 
-    fprintf(stderr, "init...\n");
+    LOG_INFO("ice9 init...\n");
 
     mpsse_init(ifnum, devstr, slow_clock);
 
-    fprintf(stderr, "reset..\n");
+    LOG_INFO("ice9 reset..\n");
 
     sram_reset();
     usleep(100);
 
-    fprintf(stderr, "cdone: %s\n", get_cdone() ? "high" : "low");
+    LOG_INFO("ice9 cdone: %s\n", get_cdone() ? "high" : "low");
 
     sram_refresh_fpga();
     sram_read_id();
     sram_read_status();
     sram_prepare();
     sram_read_status();
-    fprintf(stderr, "Bye.\n");
     sram_bitstream_burst();
     while (bufsize) {
         const int len = (bufsize < 16*1024) ? bufsize : 16*1024;
         if (verbose)
-            fprintf(stderr, "Sending %d bytes to Ice9\n", len);
+            LOG_INFO("Sending %d bytes to Ice9\n", len);
         mpsse_send_spi(buf, len);
         buf += len;
         bufsize -= len;


### PR DESCRIPTION
By default LOG_INFO/LOG_ERROR log to standard output and standard error, respectively, but the logging functions can be set to another implementation by library users.